### PR TITLE
Fix issue #5

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,19 @@ export default function extractAbbreviation(line, pos, options) {
 	while (!stream.sol()) {
 		c = stream.peek();
 
+		if (has(stack, CURLY_BRACE_R)) {
+			if (c === CURLY_BRACE_R) {
+				stack.push(c);
+				stream.pos--;
+				continue;
+			}
+
+			if (c !== CURLY_BRACE_L) {
+				stream.pos--;
+				continue;
+			}
+		}
+
 		if (isCloseBrace(c, options.syntax)) {
 			stack.push(c);
 		} else if (isOpenBrace(c, options.syntax)) {

--- a/test/extract.js
+++ b/test/extract.js
@@ -67,4 +67,10 @@ describe('Extract abbreviation', () => {
 		// Absent prefix
 		assert.strictEqual(extract('<foo>bar[a b="c"]>baz', { prefix: '&&' }), null);
 	});
+
+	it('brackets inside curly braces', () => {
+		assert.deepEqual(extract('foo div{[}+a{}'), result('div{[}+a{}', 4));
+		assert.deepEqual(extract('div{}}'), undefined);
+		assert.deepEqual(extract('div{{}'), result('{}', 4));
+	})
 });


### PR DESCRIPTION
Fixes #5 

Note that if we are making `div{[}+a{}` extractable, it should also be expandable. So this PR relies on [emmet PR#569](https://github.com/emmetio/emmet/pull/569)